### PR TITLE
feat: fix isExpiredSignedUrl function

### DIFF
--- a/src/components/app/CategorySection.tsx
+++ b/src/components/app/CategorySection.tsx
@@ -19,6 +19,8 @@ export default async function CategorySection({ category, subCategory }: Categor
     events = await getTrendingEventsBySubcategory(subCategory.name, config.TRENDING_EVENTS_BY_SUBCATEGORY_LIMIT);
   }
 
+  events.sort((a, b) => (new Date(a.datetime) < new Date(b.datetime) ? -1 : 1));
+
   return (
     <div className="flex flex-col">
       {events.length > 0 && (

--- a/src/components/app/TrendingEventsSection.tsx
+++ b/src/components/app/TrendingEventsSection.tsx
@@ -3,15 +3,17 @@ import { getTrendingEvents } from '@/lib/actions';
 import { config } from '@/lib/config';
 
 export default async function TrendingEventsSection() {
-  const trendingEvents = await getTrendingEvents(config.TRENDING_EVENTS_LIMIT);
+  let events = await getTrendingEvents(config.TRENDING_EVENTS_LIMIT);
+
+  events.sort((a, b) => (new Date(a.datetime) < new Date(b.datetime) ? -1 : 1));
 
   return (
     <>
-      {!!trendingEvents.length && (
+      {!!events.length && (
         <div data-testid="trending-events-section" className="flex flex-col px-5 py-3">
           <p className="text-2xl font-bold pl-3">Trending</p>
           <div className="pt-2">
-            <EventsCarousel events={trendingEvents} />
+            <EventsCarousel events={events} />
           </div>
         </div>
       )}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,5 +26,5 @@ export function isExpiredSignedUrl(url: string) {
   if (!expiresAt) {
     throw Error('Url not formatted properly');
   }
-  return parseInt(expiresAt) < Date.now();
+  return parseInt(expiresAt) < Math.floor(Date.now() / 1000);
 }


### PR DESCRIPTION
expiration date does not count milliseconds while Date.now() does, resulting in the expiration date being several magnitudes less causing constant recaching of cloudfront url